### PR TITLE
Updated bower.json "main: " to reference the file with the templates …

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-directive-select-usstate",
   "version": "0.2.1",
-  "main": "src/index.js",
+  "main": "build/angular-directive-select-usstates.js",
   "ignore": [
     "**/.*",
     "node_modules",


### PR DESCRIPTION
Certain tasks like grunt-injector will reference the main file defined in bower.json to determine what source file to embed in your project.  Referencing src/index.js breaks this as this file does not have the templates embedded in it.  I switched the reference to the file that works, so that the correct file is included.
